### PR TITLE
Attribute handling

### DIFF
--- a/lib/json2xml.js
+++ b/lib/json2xml.js
@@ -53,9 +53,9 @@ module.exports = function xml(json, opts) {
 				var node = json[key],
 				attributes = '';
 
-				if(opts.attributes_key && json[opts.attributes_key]){
-					Object.keys(json[opts.attributes_key]).forEach(function(k){
-						attributes += util.format(' %s="%s"', k, json[opts.attributes_key][k]);
+				if(opts.attributes_key && node[opts.attributes_key]){
+					Object.keys(node[opts.attributes_key]).forEach(function(k){
+						attributes += util.format(' %s="%s"', k, node[opts.attributes_key][k]);
 					});
 				}
 				var inner = xml(node,opts);


### PR DESCRIPTION
The script

```
var json2xml = require('json2xml');

var o = {
  r : {
    a : 1,
    b : {
      c: 2,
      attr : { foo : "bar"}
    }
  }
}

console.log(json2xml(o , { attributes_key: 'attr' }));
```

generates the output:

```
<r>
  <a>1</a>
  <b>
    <c foo="bar">2</c>
  </b>
</r>
```

But I think expected is:

```
<r>
  <a>1</a>
  <b foo="bar">
    <c>2</c>
  </b>
</r>
```